### PR TITLE
fixed issue of popping more than needed

### DIFF
--- a/lib/giphy_picker.dart
+++ b/lib/giphy_picker.dart
@@ -34,7 +34,8 @@ class GiphyPicker {
                 onSelected: (gif) {
                   result = gif;
 
-                  Navigator.popUntil(context, (Route route) => route.isFirst);
+                  Navigator.pop(context);
+                  Navigator.pop(context);
                 }),
             fullscreenDialog: true));
 


### PR DESCRIPTION
Popping all the way back to the initial screen could be unwanted behavior. This will cause it to only pop back to the screen where it was opened from.