### PR TITLE
`GiphyPreviewType` added in order to fix the preview images

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
             context: context,
             apiKey: '[YOUR GIPHY APIKEY]',
             fullScreenDialog: false,
+            previewType: GiphyPreviewType.previewWebp,
             decorator: GiphyDecorator(
               showAppBar: false,
               searchElevation: 4,

--- a/lib/giphy_picker.dart
+++ b/lib/giphy_picker.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:giphy_picker/src/model/giphy_client.dart';
 import 'package:giphy_picker/src/model/giphy_decorator.dart';
+import 'package:giphy_picker/src/model/giphy_preview_types.dart';
 import 'package:giphy_picker/src/widgets/giphy_context.dart';
 import 'package:giphy_picker/src/widgets/giphy_search_page.dart';
 
@@ -12,6 +13,7 @@ import 'src/widgets/giphy_context.dart';
 export 'package:giphy_picker/src/model/giphy_client.dart';
 export 'package:giphy_picker/src/widgets/giphy_image.dart';
 export 'package:giphy_picker/src/model/giphy_decorator.dart';
+export 'package:giphy_picker/src/model/giphy_preview_types.dart';
 
 typedef ErrorListener = void Function(dynamic error);
 
@@ -30,6 +32,7 @@ class GiphyPicker {
     GiphyDecorator decorator,
     bool fullScreenDialog = true,
     String searchText = 'Search GIPHY',
+    GiphyPreviewType previewType,
   }) async {
     GiphyGif result;
     final _decorator =
@@ -39,6 +42,7 @@ class GiphyPicker {
       MaterialPageRoute(
         builder: (BuildContext context) => GiphyContext(
           decorator: _decorator,
+          previewType: previewType ?? GiphyPreviewType.previewGif,
           child: GiphySearchPage(
             title: title,
           ),

--- a/lib/src/model/giphy_preview_types.dart
+++ b/lib/src/model/giphy_preview_types.dart
@@ -1,0 +1,10 @@
+/// Preview Type for the GIPHY image displayed in the grid view
+enum GiphyPreviewType {
+  fixedWidthSmallStill,
+  previewGif,
+  fixedHeight,
+  original,
+  previewWebp,
+  downsizedLarge,
+  originalStill,
+}

--- a/lib/src/model/giphy_repository.dart
+++ b/lib/src/model/giphy_repository.dart
@@ -124,8 +124,9 @@ class GiphyRepository extends Repository<GiphyGif> {
     }
     if (url == null) {
       url = gif.images.previewGif.url ??
-          gif.images.fixedWidthSmallStill.url ??
-          gif.images.fixedHeightDownsampled.url;
+          gif.images.fixedWidthSmallStill?.url ??
+          gif.images.fixedHeightDownsampled?.url ??
+          gif.images.original.url;
     }
 
     if (url != null) {

--- a/lib/src/model/giphy_repository.dart
+++ b/lib/src/model/giphy_repository.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 import 'package:giphy_picker/src/model/giphy_client.dart';
+import 'package:giphy_picker/src/model/giphy_preview_types.dart';
 import 'package:giphy_picker/src/model/repository.dart';
 import 'package:giphy_picker/giphy_picker.dart';
 import 'package:http/http.dart' as http;
@@ -20,14 +20,16 @@ class GiphyRepository extends Repository<GiphyGif> {
   final int maxConcurrentPreviewLoad;
   GiphyClient _giphyClient;
   int _previewLoad = 0;
+  final GiphyPreviewType previewType;
 
-  GiphyRepository(
-      {@required String apiKey,
-      @required this.getCollection,
-      this.maxConcurrentPreviewLoad = 4,
-      int pageSize = 25,
-      ErrorListener onError})
-      : super(pageSize: pageSize, onError: onError) {
+  GiphyRepository({
+    @required String apiKey,
+    @required this.getCollection,
+    this.maxConcurrentPreviewLoad = 4,
+    int pageSize = 25,
+    ErrorListener onError,
+    this.previewType,
+  }) : super(pageSize: pageSize, onError: onError) {
     assert(getCollection != null);
     assert(maxConcurrentPreviewLoad != null);
     _giphyClient = GiphyClient(apiKey: apiKey, client: _client);
@@ -96,8 +98,34 @@ class GiphyRepository extends Repository<GiphyGif> {
 
   Future<Uint8List> _loadPreviewImage(GiphyGif gif) async {
     // fallback to still image if preview is empty
-    final url =
-        gif.images.previewGif.url ?? gif.images.fixedWidthSmallStill.url;
+    String url;
+    switch (previewType) {
+      case GiphyPreviewType.fixedWidthSmallStill:
+        url = gif.images.fixedWidthSmallStill.url;
+        break;
+      case GiphyPreviewType.previewGif:
+        url = gif.images.previewGif.url;
+        break;
+      case GiphyPreviewType.fixedHeight:
+        url = gif.images.fixedHeight.url;
+        break;
+      case GiphyPreviewType.original:
+        url = gif.images.original.url;
+        break;
+      case GiphyPreviewType.previewWebp:
+        url = gif.images.previewWebp.url;
+        break;
+      case GiphyPreviewType.downsizedLarge:
+        url = gif.images.downsizedLarge.url;
+        break;
+      case GiphyPreviewType.originalStill:
+        url = gif.images.originalStill.url;
+        break;
+    }
+    if (url == null) {
+      url = gif.images.previewGif.url ?? gif.images.fixedWidthSmallStill.url;
+    }
+
     if (url != null) {
       return await GiphyImage.load(url, client: _client);
     }
@@ -106,13 +134,16 @@ class GiphyRepository extends Repository<GiphyGif> {
   }
 
   /// The repository of trending gif images.
-  static Future<GiphyRepository> trending(
-      {@required String apiKey,
-      String rating = GiphyRating.g,
-      bool sticker = false,
-      ErrorListener onError}) async {
+  static Future<GiphyRepository> trending({
+    @required String apiKey,
+    String rating = GiphyRating.g,
+    bool sticker = false,
+    ErrorListener onError,
+    GiphyPreviewType previewType,
+  }) async {
     final repo = GiphyRepository(
         apiKey: apiKey,
+        previewType: previewType,
         getCollection: (client, offset, limit) => client.trending(
             offset: offset, limit: limit, rating: rating, sticker: sticker),
         onError: onError);
@@ -130,9 +161,11 @@ class GiphyRepository extends Repository<GiphyGif> {
       String rating = GiphyRating.g,
       String lang = GiphyLanguage.english,
       bool sticker = false,
+      GiphyPreviewType previewType,
       ErrorListener onError}) async {
     final repo = GiphyRepository(
         apiKey: apiKey,
+        previewType: previewType,
         getCollection: (client, offset, limit) => client.search(query,
             offset: offset,
             limit: limit,

--- a/lib/src/model/giphy_repository.dart
+++ b/lib/src/model/giphy_repository.dart
@@ -101,29 +101,31 @@ class GiphyRepository extends Repository<GiphyGif> {
     String url;
     switch (previewType) {
       case GiphyPreviewType.fixedWidthSmallStill:
-        url = gif.images.fixedWidthSmallStill.url;
+        url = gif.images.fixedWidthSmallStill?.url;
         break;
       case GiphyPreviewType.previewGif:
-        url = gif.images.previewGif.url;
+        url = gif.images.previewGif?.url;
         break;
       case GiphyPreviewType.fixedHeight:
-        url = gif.images.fixedHeight.url;
+        url = gif.images.fixedHeight?.url;
         break;
       case GiphyPreviewType.original:
         url = gif.images.original.url;
         break;
       case GiphyPreviewType.previewWebp:
-        url = gif.images.previewWebp.url;
+        url = gif.images.previewWebp?.url;
         break;
       case GiphyPreviewType.downsizedLarge:
-        url = gif.images.downsizedLarge.url;
+        url = gif.images.downsizedLarge?.url;
         break;
       case GiphyPreviewType.originalStill:
-        url = gif.images.originalStill.url;
+        url = gif.images.originalStill?.url;
         break;
     }
     if (url == null) {
-      url = gif.images.previewGif.url ?? gif.images.fixedWidthSmallStill.url;
+      url = gif.images.previewGif.url ??
+          gif.images.fixedWidthSmallStill.url ??
+          gif.images.fixedHeightDownsampled.url;
     }
 
     if (url != null) {

--- a/lib/src/widgets/giphy_context.dart
+++ b/lib/src/widgets/giphy_context.dart
@@ -14,6 +14,7 @@ class GiphyContext extends InheritedWidget {
   final bool showPreviewPage;
   final GiphyDecorator decorator;
   final String searchText;
+  final GiphyPreviewType previewType;
 
   /// Debounce delay when searching
   final Duration searchDelay;
@@ -31,6 +32,7 @@ class GiphyContext extends InheritedWidget {
     this.searchText = 'Search Giphy',
     this.searchDelay,
     this.decorator,
+    this.previewType,
   }) : super(key: key, child: child);
 
   void select(GiphyGif gif) {

--- a/lib/src/widgets/giphy_search_view.dart
+++ b/lib/src/widgets/giphy_search_view.dart
@@ -115,6 +115,7 @@ class _GiphySearchViewState extends State<GiphySearchView> {
               apiKey: giphy.apiKey,
               rating: giphy.rating,
               sticker: giphy.sticker,
+              previewType: giphy.previewType,
               onError: giphy.onError)
           : GiphyRepository.search(
               apiKey: giphy.apiKey,
@@ -122,7 +123,9 @@ class _GiphySearchViewState extends State<GiphySearchView> {
               rating: giphy.rating,
               lang: giphy.language,
               sticker: giphy.sticker,
-              onError: giphy.onError));
+              previewType: giphy.previewType,
+              onError: giphy.onError,
+            ));
 
       // scroll up
       if (_scrollController.hasClients) {


### PR DESCRIPTION
In order to fix this issue: https://github.com/firstfloorsoftware/giphy_picker/issues/15

This PR adds a new param `GiphyPreviewType` . The value by default is `previewGif`.

This is a sample using the new param with the value `previewWebp` :

```dart

          final gif = await GiphyPicker.pickGif(
            context: context,
            apiKey: '[YOUR GIPHY APIKEY]',
            fullScreenDialog: false,
            previewType: GiphyPreviewType.previewWebp,
            decorator: GiphyDecorator(
              showAppBar: false,
              searchElevation: 4,
              giphyTheme: ThemeData.dark().copyWith(
                inputDecorationTheme: InputDecorationTheme(
                  border: InputBorder.none,
                  enabledBorder: InputBorder.none,
                  focusedBorder: InputBorder.none,
                  contentPadding: EdgeInsets.zero,
                ),
              ),
            ),
          );
```

You can see now how the image is not blurry.


![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-07 at 00 04 20](https://user-images.githubusercontent.com/4898256/95289794-493baf00-0831-11eb-8683-9d12907b1a51.png)
